### PR TITLE
fast-search: convert s2ws with mbstowcs

### DIFF
--- a/fast-search/Main.cpp
+++ b/fast-search/Main.cpp
@@ -105,18 +105,7 @@ const std::string currentDateTime() {
   return buf;
 }
 
-// std::string kor2Eng(const char* target) {
-//    //
-//    //  HangulConverter가 wchar_t 기반으로 구현되어 있어서
-//    //  utf-8 => unicode 해줘야함
-//    //
-//    wchar_t unicode[1024];
-//    std::mbstowcs(unicode, target, 1024);
-//    char kor2engtypo[1024 * 3];
-//    Utility::HangulConverter::total_disassembly(unicode, kor2engtypo);
-//    return std::string(kor2engtypo);
-//}
-
+#if _WIN32
 std::wstring s2ws(const std::string &str) {
   int size_needed =
       MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
@@ -132,6 +121,20 @@ std::string kor2Eng(const char *target) {
   Utility::HangulConverter::total_disassembly(search.c_str(), kor2engtypo);
   return std::string(kor2engtypo);
 }
+
+#else
+std::string kor2Eng(const char* target) {
+    //
+    //  HangulConverter가 wchar_t 기반으로 구현되어 있어서
+    //  utf-8 => unicode 해줘야함
+    //
+    wchar_t unicode[1024];
+    std::mbstowcs(unicode, target, 1024);
+    char kor2engtypo[1024 * 3];
+    Utility::HangulConverter::total_disassembly(unicode, kor2engtypo);
+    return std::string(kor2engtypo);
+}
+#endif
 
 std::string
 result2Json(const std::vector<std::pair<MergedInfo *, double>> &result,


### PR DESCRIPTION
리눅스에서 쓰려는데 MultiByteToWideChar 때문에 빌드 안되서 수정 했습니다.

빌드 후 violet-message-search-local 웹에서 정상 작동확인.
맥에서는 테스트 안해봤습니다.